### PR TITLE
Enable validation of all inputs in all steps on form submission.

### DIFF
--- a/materialize-stepper.js
+++ b/materialize-stepper.js
@@ -228,7 +228,7 @@ $.fn.activateStepper = function(options) {
          $stepper.wrap( '<form action="'+action+'" method="'+method+'"></div>' );
       }
 
-      $stepper.data('settings', {linearStepsNavigation: settings.linearStepsNavigation,autoFocusInput: settings.autoFocusInput,showFeedbackLoader:settings.showFeedbackLoader});
+      $stepper.data('settings', {linearStepsNavigation: settings.linearStepsNavigation,autoFocusInput: settings.autoFocusInput,showFeedbackLoader:settings.showFeedbackLoader, openStepOnValidationError: settings.openStepOnValidationError});
       $stepper.find('li.step.active').openAction(1);
       $stepper.find('>li').removeAttr("data-last");
       $stepper.find('>li.step').last().attr('data-last', 'true');


### PR DESCRIPTION
Enables validation of all inputs in all steps on form submission when using a non-linear stepper. It marks all steps with invalid inputs as 'wrong'. It also jumps to the first step with validation errors (can be turned off). This fixes Kinark/Materialize-stepper#17.