### PR TITLE
Stepper navigation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ $(function(){
       linearStepsNavigation: true, //allow navigation by clicking on the next and previous steps on linear steppers
       autoFocusInput: true, //since 2.1.1, stepper can auto focus on first input of each step
       autoFormCreation: true, //control the auto generation of a form around the stepper (in case you want to disable it)
-      showFeedbackLoader: true //set if a loading screen will appear while feedbacks functions are running
+      showFeedbackLoader: true //set if a loading screen will appear while feedbacks functions are running,
+      parallel: false // By default we don't assume the stepper is parallel, this is set to true when stepper has .parallel class
    });
 });
 </script>
@@ -194,12 +195,18 @@ or inline:
 
 **IMPORTANT: THE HEIGHT OF THE ".stepper-content" TAG IS SUBTRACTED BY 84PX. SO, FOR EXAMPLE, IF YOU WANT YOUR CONTENT TO HAVE 400PX HEIGHT, YOU'LL NEED TO SET THE "min-height" OF YOUR PRIMARY "ul" TAG TO 484PX!**
 
-### Linear and non-linear
+### Linear, non-linear and parallel
 
 If you want users to change between steps freely (without validations or the obligation to advance a step at a time), just remove .linear class from the primary ul:
 
 ```html
 <ul class="stepper">...</ul>
+```
+
+If you want users to change between steps freely AND have all previous steps validated add the .parallel class to the primary ul:
+
+```html
+<ul class="stepper parallel">...</ul>
 ```
 
 ### Form and inputs
@@ -318,6 +325,33 @@ $('selector').showError('error message');
 ```
 
 That is a shorthand with additions to showErrors function of jQueryValidation plugin.
+
+### Custom Validation
+
+Custom validation can be included when using a Parallel stepper. It can be used for the other stepper types, but that isn't necessarily useful. You define a custom validation function in the ".next-step" element like this:
+
+```html
+<button class="waves-effect waves-dark btn next-step" data-validator="validateEmailDB">CONTINUE</button>
+```
+
+This "validateEmailDB" function is expected to return a boolean value. If it is anything other than a boolean value unexpected behaviour might occur.
+
+Tip: When using both Feedback and Custom Validation it is best practice to use the validator method for validation and the feedback function to handle the step change. Like so:
+
+```html
+function validateEmailDB() {
+ ... // email validation here
+ return true // or false according to validation of course.
+}
+
+function checkEmailDB() {
+    if(validateEmailDB()) {
+        ... // Handle successful step validation behaviour here
+    } else {
+        ... // Handle unsuccessful step validation behaviour here
+    }
+}
+```
 
 ### Custom Events
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -616,6 +616,6 @@ $(selector).nextStep();
    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.15.0/jquery.validate.min.js"></script>
    <!-- <script src="./materialize-stepper.min.js"></script> -->
    <script src="prism.js"></script>
-   <script src="C:/Users/Floris.List/Projects/Materialize-stepper/materialize-stepper.js"></script>
+   <script src="https://rawgit.com/Kinark/Materialize-stepper/master/materialize-stepper.min.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,6 +260,67 @@
                   </div>
                </div>
 
+               <div class="section scrollspy" id="parallel">
+                  <div class="row">
+                     <div class="col s12"><h5>Parallel Stepper</h5></div>
+                     <div class="col l6 m12 s12">
+                        <div class="card">
+                           <div class="card-content">
+                              <ul class="stepper parallel">
+                                 <li class="step active">
+                                    <div data-step-label="Just add a data-step-label!" class="step-title waves-effect waves-dark">Step 1</div>
+                                    <div class="step-content">
+                                       <div class="row">
+                                          <div class="input-field col s12">
+                                             <input name="email" type="email" class="validate" required>
+                                             <label for="email">Your e-mail</label>
+                                          </div>
+                                       </div>
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue next-step">CONTINUE</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li class="step">
+                                    <div class="step-title waves-effect waves-dark">Step 2</div>
+                                    <div class="step-content">
+                                       <div class="row">
+                                          <div class="input-field col s12">
+                                             <input id name="password" type="password" class="validate" required>
+                                             <label for="password">Your password</label>
+                                          </div>
+                                       </div>
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue next-step">CONTINUE</button>
+                                          <button class="waves-effect waves-dark btn-flat previous-step">BACK</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li class="step">
+                                    <div class="step-title waves-effect waves-dark">Step 3</div>
+                                    <div class="step-content">
+                                       Finish!
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue" type="submit">SUBMIT</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                              </ul>
+                           </div>
+                        </div>
+                     </div>
+                     <div class="col l6 m12 s12">
+                        <p>
+
+                           The parallel stepper is best of both worlds. You get to navigate freely through your stepper, but with continuous validation. Parallel behaves the same as the Non-Linear Stepper, but when opening a step all previous steps are validated by both custom validation (if present) as well as regular validation (if you're using the jQuery Validation Plugin).                        </p>
+                        <p><b>Example:</b></p>
+                        <pre class="language-markup"><code class=" language-markup">
+&lt;ul class="stepper parallel"&gt;...&lt;/ul&gt;
+                        </code></pre>
+                     </div>
+                  </div>
+               </div>
+
                <div class="section scrollspy" id="horizontal-stepper">
                   <div class="row">
                      <div class="col s12"><h5>Horizontal Stepper</h5></div>
@@ -392,6 +453,78 @@ $(selector).nextStep();
                   </div>
                </div>
 
+               <div class="section scrollspy" id="custom-validate-step">
+                  <div class="row">
+                     <div class="col s12"><h5>Custom Validation Step</h5></div>
+                     <div class="col l6 m12 s12">
+                        <div class="card">
+                           <div class="card-content">
+                              <ul class="stepper parallel" id="custom-validation">
+                                 <li class="step active">
+                                    <div  class="step-title waves-effect waves-dark">Step 1</div>
+                                    <div class="step-content">
+                                       <div class="row">
+                                          <div class="input-field col s12">
+                                             <input name="email" type="email" class="validate"  placeholder="This field is not required">
+                                             <label for="email">Your e-mail</label>
+                                          </div>
+                                       </div>
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue next-step" data-feedback="someOtherFunction">CONTINUE</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li class="step">
+                                    <div class="step-title waves-effect waves-dark">Step 2</div>
+                                    <div class="step-content">
+                                       <div class="row">
+                                          <div class="input-field col s12">
+                                             <input id name="password" type="password" class="validate" required>
+                                             <label for="password">Your password</label>
+                                          </div>
+                                       </div>
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue next-step" data-feedback="someOtherFunction">CONTINUE</button>
+                                          <button class="waves-effect waves-dark btn-flat previous-step">BACK</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                                 <li class="step">
+                                    <div class="step-title waves-effect waves-dark">Step 3</div>
+                                    <div class="step-content">
+                                       Finish!
+                                       <div class="step-actions">
+                                          <button class="waves-effect waves-dark btn blue" type="submit">SUBMIT</button>
+                                       </div>
+                                    </div>
+                                 </li>
+                              </ul>
+                           </div>
+                        </div>
+                     </div>
+                     <div class="col l6 m12 s12">
+                        <p>
+                           This functionality is mainly focused when using the Parallel Stepper. When previous steps are validated you might want to add your own custom validation if jQuery Validation doesn´t suffice.
+                        </p>
+                        <p>
+                           By adding the 'data-validator' HTML tag the given function will be executed and is expected to return a boolean value. If the value is not boolean, unexpected behaviour is most likely to occur.
+                        </p>
+                        <p>
+                           Tip: If you are planning on using both the Custom Validation and Feedback, use the Custom Validation function to validate and the Feedback function to invoke the nextStep behaviour.
+                        </p>
+                        <p>
+                           For a more elaborate example please refer to <a href="https://codepen.io/anon/pen/rYZome">Parallel Stepper Example</a>
+                        </p>
+                        <p><b>Example:</b></p>
+                        <pre class="language-markup"><code class=" language-markup">
+&lt;button class="waves-effect waves-dark btn blue next-step" data-validator="someOtherFunction"&gt;
+   CONTINUE
+&lt;/button&gt;
+                        </code></pre>
+                     </div>
+                  </div>
+               </div>
+
                <div class="section scrollspy" id="changelog">
                   <div class="row">
                      <div class="col s12"><h5>Changelog</h5></div>
@@ -469,6 +602,10 @@ $(selector).nextStep();
       setTimeout(function(){$('#feedbacker').nextStep();},1000);
    }
 
+   function someOtherFunction() {
+       return true;
+   }
+
    $(document).ready(function(){
       $('.toc-wrapper').pushpin({ top: $('.toc-wrapper').offset().top, offset: 77 });
       $('.scrollspy').scrollSpy();
@@ -479,6 +616,6 @@ $(selector).nextStep();
    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.15.0/jquery.validate.min.js"></script>
    <!-- <script src="./materialize-stepper.min.js"></script> -->
    <script src="prism.js"></script>
-   <script src="https://rawgit.com/Kinark/Materialize-stepper/master/materialize-stepper.min.js"></script>
+   <script src="C:/Users/Floris.List/Projects/Materialize-stepper/materialize-stepper.js"></script>
 </body>
 </html>

--- a/materialize-stepper.js
+++ b/materialize-stepper.js
@@ -131,7 +131,7 @@ $.fn.nextStep = function(callback, activefb, e) {
    var next = $(this.children('.step:visible')).index($(active))+2;
    var feedback = active.find('.next-step').length > 1 ? (e ? $(e.target).data("feedback") : undefined) : active.find('.next-step').data("feedback");
    // If the stepper is parallel, we want to validate the input of the current active step. Not all elements.
-   if(($(stepper).hasClass('parallel') && $(active).validateStepInput()) || form.isValid()) {
+   if((settings.parallel && $(active).validateStep()) || (!settings.parallel && form.isValid())) {
       if(feedback && activefb) {
          if(settings.showFeedbackLoader) stepper.activateFeedback();
          return window[feedback].call();
@@ -204,7 +204,8 @@ $.fn.activateStepper = function(options) {
       linearStepsNavigation: true,
       autoFocusInput: true,
       showFeedbackLoader: true,
-      autoFormCreation: true
+      autoFormCreation: true,
+      parallel: false // By default we don't assume the stepper is parallel
    }, options);
    $(document).on('click', function(e){
       if(!$(e.target).parents(".stepper").length){
@@ -222,14 +223,14 @@ $.fn.activateStepper = function(options) {
          $stepper.wrap( '<form action="'+action+'" method="'+method+'"></form>' );
       }
 
-      $stepper.data('settings', {linearStepsNavigation: settings.linearStepsNavigation,autoFocusInput: settings.autoFocusInput,showFeedbackLoader:settings.showFeedbackLoader});
+      $stepper.data('settings', {linearStepsNavigation: settings.linearStepsNavigation,autoFocusInput: settings.autoFocusInput,showFeedbackLoader:settings.showFeedbackLoader, parallel:$stepper.hasClass('parallel')});
       $stepper.find('li.step.active').openAction(1);
       $stepper.find('>li').removeAttr("data-last");
       $stepper.find('>li.step').last().attr('data-last', 'true');
 
       $stepper.on("click", '.step:not(.active)', function () {
          var object = $($stepper.children('.step:visible')).index($(this));
-         if($stepper.hasClass('parallel') && validation) { // Invoke parallel stepper behaviour
+         if($stepper.data('settings').parallel && validation) { // Invoke parallel stepper behaviour
             $(this).addClass('temp-active');
             $stepper.validatePreviousSteps()
             $stepper.openStep(object + 1);
@@ -311,15 +312,19 @@ $.fn.validateStep = function() {
     if(this.validateStepInput()) { // If initial base validation succeeded go on
       if(validator) { // If a custom validator is given also call that validator
          if (window[validator].call()) {
-             return step.removeClass('wrong').addClass('done');
+             step.removeClass('wrong').addClass('done');
+             return true;
          }
          else {
-             return step.removeClass('done').addClass('wrong');
+             step.removeClass('done').addClass('wrong');
+             return false;
          }
       }
-      return step.removeClass('wrong').addClass('done');
+      step.removeClass('wrong').addClass('done');
+      return true;
     } else {
-      return step.removeClass('done').addClass('wrong');
+      step.removeClass('done').addClass('wrong');
+      return false;
     }
 };
 

--- a/materialize-stepper.js
+++ b/materialize-stepper.js
@@ -130,7 +130,8 @@ $.fn.nextStep = function(callback, activefb, e) {
    var active = this.find('.step.active');
    var next = $(this.children('.step:visible')).index($(active))+2;
    var feedback = active.find('.next-step').length > 1 ? (e ? $(e.target).data("feedback") : undefined) : active.find('.next-step').data("feedback");
-   if(form.isValid()) {
+   // If the stepper is parallel, we want to validate the input of the current active step. Not all elements.
+   if(($(stepper).hasClass('parallel') && $(active).validateStepInput()) || form.isValid()) {
       if(feedback && activefb) {
          if(settings.showFeedbackLoader) stepper.activateFeedback();
          return window[feedback].call();

--- a/materialize-stepper.js
+++ b/materialize-stepper.js
@@ -228,7 +228,7 @@ $.fn.activateStepper = function(options) {
 
       $stepper.on("click", '.step:not(.active)', function () {
          var object = $($stepper.children('.step:visible')).index($(this));
-         if($stepper.hasClass('parallel')) { // Invoke parallel stepper behaviour
+         if($stepper.hasClass('parallel') && validation) { // Invoke parallel stepper behaviour
             $(this).addClass('temp-active');
             $stepper.validatePreviousSteps()
             $stepper.openStep(object + 1);


### PR DESCRIPTION
Implemented stepper add on that introduces parallel stepper behaviour with each previous step being validated. Custom validators are also introduced per step in order for the user to define custom step validation.

This add on gives the user more freedom in navigating through the stepper with form validation taken into account.

The new introduced stepper type is 'parallel', coming from parallel form validation behaviour. A user is now able to navigate freely through the stepper with all previous steps being validated.

I introduced a new option for the action button element, namely a custom validator for a step. A user can now define custom validation when the behaviour is set to parallel. This function will be called in the validation of the previous steps from the current step.

Example usage:
`<div class="step-actions input-field">`
`   <button class="waves-effect waves-dark btn next-step" data-validator="customValidator">CONTINUE</button>`
`</div>`

A use case for this is whenever there's a form that needs to be revisited often and only step 'x' needs to edited. It would be a tedious job for the user to constantly click on next or when linear is not set to have the user validate every form step by hand.