### PR TITLE
Fix #51 selected status of radio buttons when calculating height

### DIFF
--- a/src/js/mstepper.js
+++ b/src/js/mstepper.js
@@ -721,6 +721,11 @@ class MStepper {
       clone.style.opacity = '0';
       clone.style.zIndex = '-999999';
       clone.style.pointerEvents = 'none';
+      // Rename the radio buttons in the cloned node as only 1 radio button is allowed to be selected with the same name in the DOM.
+      const radios = clone.querySelectorAll('[type="radio"]');
+      radios.forEach(radio => {
+         radio.name = "__" + radio.name + "__"; 
+      });
       // Inserts it before the hidden element
       const insertedElement = el.parentNode.insertBefore(clone, el);
       // Gets it's height


### PR DESCRIPTION
Fix #51 
As only 1 radio button with the same name is allowed to be selected, inserting the cloned radios will cause the others be unchecked therefore losing the status of the radio buttons.
